### PR TITLE
perf: boost speeds by up to 5x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ vendor
 .cache
 .deno
 .npm
+lib-*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,25 +46,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4-compression"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761104bf97f13a3caf47d822498a0760a10d00d220148bac2669f63fc3bb8270"
-
-[[package]]
 name = "lz4-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lol_alloc",
- "lz4-compression",
+ "lz4_flex",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.1"
+name = "lz4_flex"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "42c51df9d8d4842336c835df1d85ed447c4813baa237d033d95128bf5552ad8a"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "proc-macro2"
@@ -100,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +117,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
   name    = "lz4-wasm"
-  version = "0.1.0"
+  version = "0.2.0"
   authors = ["Nick Berlette <nick@berlette.com>"]
   edition = "2024"
 
@@ -17,11 +17,14 @@
   mt         = ["alloc"]
 
 [dependencies]
-  lz4-compression = "=0.7.0"
-  wasm-bindgen    = { version = "=0.2.100", default-features = false }
-  lol_alloc       = { version = "=0.4.1", optional = true }
+  lz4_flex = { version = "=0.9.2", default-features = false, features = [
+    "checked-decode",
+  ] }
+  wasm-bindgen = { version = "=0.2.100", default-features = false }
+  lol_alloc = { version = "=0.4.1", optional = true }
 
 [profile.release]
-  lto       = true
-  opt-level = "s"     # we build for speed round these parts
-  panic     = "abort"
+  lto           = true
+  codegen-units = 1
+  opt-level     = "s"     # we build for speed round these parts
+  panic         = "abort"

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Continuing with the same example, let's ensure that the decompressed data
 matches the original data passed to the compressor.
 
 ```ts
-import { decompress } from "@nick/lz4";
+import { compress, decompress } from "@nick/lz4";
 
 const data = await fetch(
   "https://jsr.io/@nick/lz4@0.1.0/lib/lz4.js",
@@ -207,7 +207,7 @@ ambitious) goals in mind. I wanted to create a ultra-lightweight compression
 utility that could be used in a variety of runtime environments without any
 dependencies.
 
-- [x] **Reduce** WASM binary size as much as possible - cut in _half_!
+- [x] **Reduce** WASM binary size as much as possible. It's nearly 50% smaller!
 - [x] **Extend** compatibility to support **all** WebAssembly-friendly runtimes
 - [x] **Enable** the `no_std` attribute, emancipating it from rust-std
 - [x] **Switch** to [`lol_alloc`] for lightweight, jovial memory allocation

--- a/deno.json
+++ b/deno.json
@@ -8,8 +8,14 @@
     "url": "https://github.com/nberlette/lz4-wasm#readme"
   },
   "exports": "./mod.ts",
+  "tasks": {
+    "test": "deno test -A --no-check=remote --parallel --doc --clean --coverage=.coverage --permit-no-files",
+    "lcov": "deno coverage --lcov --output=lcov.info .coverage",
+    "build": "deno run -Aq ./scripts/build.ts",
+    "check": "deno run build && deno fmt --check && deno lint && deno run test"
+  },
   "publish": {
     "include": ["**/*.ts", "**/*.js*", "**/*.md", "LICENSE"],
-    "exclude": ["**/.*", "!lib"]
+    "exclude": ["**/.*", "!lib", "**/*.test.*", "**/*.bench.*"]
   }
 }

--- a/lz4.bench.ts
+++ b/lz4.bench.ts
@@ -1,0 +1,62 @@
+import * as lz4 from "./mod.ts";
+import * as lz4_010 from "jsr:@nick/lz4@0.1.0";
+import * as lz4_wasm from "https://unpkg.com/lz4-wasm@0.9.2/lz4_wasm_bg.js";
+import * as lz4_legacy from "https://deno.land/x/lz4@v0.1.0/mod.ts";
+import * as lz4js from "npm:lz4js@0.2.0";
+
+import p from "./deno.json" with { type: "json" };
+
+const bytes_4mb = await fetch(
+  "https://plugins.dprint.dev/typescript-0.94.0.wasm",
+).then((res) => res.bytes());
+
+const bytes_10k = bytes_4mb.slice(0, 10 * 1024);
+const bytes_256k = bytes_4mb.slice(0, 256 * 1024);
+const bytes_512k = bytes_4mb.slice(0, 512 * 1024);
+const bytes_1mb = bytes_4mb.slice(0, 1 * 1024 * 1024);
+const bytes_2mb = bytes_4mb.slice(0, 2 * 1024 * 1024);
+
+const targets = [
+  { name: `${p.name}     (${p.version})`, lz4 },
+  { name: `${p.name}     (0.1.0)`, lz4: lz4_010 },
+  { name: "deno/x/lz4    (0.1.0)", lz4: lz4_legacy },
+  { name: "npm:lz4-wasm  (0.9.2)", lz4: lz4_wasm },
+  { name: "npm:lz4js     (0.2.0)", lz4: lz4js },
+] as const;
+
+const fixtures = [
+  { group: "10k", data: bytes_10k },
+  { group: "256k", data: bytes_256k },
+  { group: "512k", data: bytes_512k },
+  { group: "1mb", data: bytes_1mb },
+  { group: "2mb", data: bytes_2mb },
+  { group: "4mb", data: bytes_4mb },
+] as const;
+
+for (const { name, lz4 } of targets) {
+  for (let { group, data } of fixtures) {
+    group = "compress - " + group;
+    Deno.bench({
+      name,
+      group,
+      warmup: 100,
+      // n: 1_000,
+      fn: () => {
+        lz4.compress(data);
+      },
+    });
+
+    const compressed = lz4.compress(data);
+
+    group = "de" + group;
+    Deno.bench({
+      name,
+      group,
+      warmup: 100,
+      // n: 1_000,
+      fn: () => {
+        lz4.decompress(compressed);
+      },
+    });
+  }
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env -S deno run -Aq --no-config
+
+import { runWasmOpt } from "./wasm_opt.ts";
+import { $ } from "jsr:@david/dax@0.42.0";
+import { colors } from "jsr:@can/si@0.1.0-rc.1/colors";
+
+function rewriteWasmExports(src: string, path: string) {
+  return src.replace(
+    /^\s*export\s+\*\s+from\s+(["'])(\S+?\.internal\.m?js)\1;?\s*$/gm,
+    (_, q, p) => {
+      const internal = Deno.readTextFileSync(
+        path.replace(/(?<=\/)[^/]+$/, p).replace(/\/\.\//g, "/"),
+      );
+      const re =
+        /export\s+(?:const|function|class)\s+((?!_)[^\s(={]+?)\s*(?:[(={])/g;
+      const exports = new Set<string>();
+      for (const m of internal.matchAll(re)) exports.add(m[1]);
+      return $.dedent`
+      export {
+        ${[...exports].join(",\n  ")},
+      } from ${q}${p}${q};
+    `;
+    },
+  );
+}
+
+async function optimize(path?: string, optLevel = "-O4") {
+  let src = await Deno.readTextFile(path ||= "./lib/lz4.js");
+
+  // remove internal exports from the public API
+  // (there's no reason to expose all of the `__wbg_*` stuff to the user)
+  src = rewriteWasmExports(src, path);
+
+  const startMark = 'const bytes = base64decode("', endMark = '");\n';
+  let start = src.indexOf(startMark);
+  const end = src.indexOf(endMark, start);
+  if (start === -1 || end === -1) {
+    console.error(
+      colors.bold.red(" ✖️ Error") +
+        ": No base64 encoded bytes found in " +
+        path,
+    );
+    Deno.exit(1);
+  }
+  start += startMark.length;
+  const base64 = src.slice(start, end).trim();
+  const bytes = Uint8Array.from(
+    atob(base64.replaceAll(/\\|\s+/g, "")),
+    (c) => c.charCodeAt(0),
+  );
+  const optimizedBytes = await runWasmOpt(bytes, optLevel);
+  const optimized = btoa(
+    optimizedBytes.reduce((a, b) => a + String.fromCharCode(b), ""),
+  ).replace(/.{77}/g, "$&\\\n");
+  const out = src.slice(0, start) + optimized + src.slice(end);
+  await Deno.writeTextFile(path, out);
+
+  // we always write notices and debug info to stderr.
+  // stdout is reserved for output intended to be piped to other programs.
+  const pctSavings = (src.length - out.length) / src.length * 100;
+  console.warn(
+    "\n" +
+      colors.bold.green(" ✔️ Optimized") +
+      " inline WebAssembly from " +
+      colors.red(prettyBytes(src.length)) +
+      " ⇒ " +
+      colors.bold.underline.green(prettyBytes(out.length)) +
+      ". You saved " +
+      colors.bold.yellow(pctSavings.toFixed(2) + "%") +
+      "!\n",
+  );
+}
+
+async function build(...args: string[]) {
+  args = [
+    "run",
+    "-Aq",
+    "--no-config",
+    "jsr:@deno/wasmbuild@0.19.1",
+    "--inline",
+    "--skip-opt",
+    ...args,
+  ];
+
+  const p = new Deno.Command(Deno.execPath(), {
+    args,
+    stdin: "inherit",
+    stderr: "inherit",
+    stdout: "inherit",
+  }).spawn();
+
+  const out = await p.output();
+  if (out.code !== 0) {
+    console.error(
+      colors.bold.red(" ✖️ Error") +
+        ": Failed to build the WASM module.",
+    );
+    console.error("\n" + new TextDecoder().decode(out.stderr) + "\n");
+    Deno.exit(1);
+  }
+
+  let outDir = "lib";
+  if (args.includes("--out")) {
+    const outIndex = args.indexOf("--out");
+    if (outIndex + 1 < args.length) {
+      outDir = args[outIndex + 1];
+    }
+  }
+  const path = `${outDir}/lz4.js`;
+
+  await optimize(path, "-O4");
+
+  console.error(
+    colors.bold.green(" ✔️ Success") +
+      ": Built and optimized the WASM module at " +
+      colors.bold.underline.green(path),
+  );
+}
+
+function prettyBytes(
+  size: number | string,
+  precision = 2,
+  iec = false,
+  unitOverride?: string,
+): string {
+  const units_si = ["B", "KB", "MB", "GB", "TB", "PB"] as const;
+  const units_iec = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"] as const;
+  size = +size;
+  if (isNaN(size) || !isFinite(size)) return "NaN";
+  const units = iec ? units_iec : units_si;
+  const factor = iec ? 1024 : 1000;
+  let i = 0;
+  for (i = 0; size >= factor && i < units.length - 1; size /= factor, i++);
+  size = (+size.toFixed(precision)).toLocaleString(["en-US"], {
+    useGrouping: true,
+    maximumFractionDigits: precision,
+    style: "decimal",
+  });
+  return `${size} ${unitOverride ?? units[i]}`;
+}
+
+if (import.meta.main) await build(...Deno.args);

--- a/scripts/wasm_opt.ts
+++ b/scripts/wasm_opt.ts
@@ -1,0 +1,175 @@
+#!/usr/bin/env -S deno run -Aq
+
+// Lifted from @deno/wasmbuild@0.19.1
+// Copyright (c) 2018-2025 the Deno authors. MIT license.
+
+import { UntarStream } from "jsr:/@std/tar@^0.1.4/untar-stream";
+import { colors } from "jsr:@can/si@0.1.0-rc.1/colors";
+import { createTempFile } from "jsr:@david/temp@^0.1.1";
+import { Path } from "jsr:@david/path@^0.2.0";
+
+const wasmOptFileName = Deno.build.os === "windows"
+  ? "wasm-opt.exe"
+  : "wasm-opt";
+const tag = "version_121";
+
+export async function runWasmOpt(fileBytes: Uint8Array, ...args: string[]) {
+  const binPath = await getWasmOptBinaryPath();
+  using outputTempFile = await createTempFile();
+  using inputTempFile = await createTempFile();
+  await inputTempFile.write(fileBytes);
+  if (
+    !args.length ||
+    !args.some((arg) => arg.startsWith("-O") || arg.startsWith("--opt"))
+  ) {
+    args.unshift("-Os");
+  }
+  if (!args.includes("--enable-bulk-memory-opt")) {
+    args.push("--enable-bulk-memory-opt");
+  }
+  if (!args.includes("--all-features")) {
+    args.push("--all-features");
+  }
+  args.push(
+    inputTempFile.toString(),
+    "-o",
+    outputTempFile.toString(),
+  );
+
+  const p = new Deno.Command(binPath.toString(), {
+    args,
+    stdin: "inherit",
+    stderr: "inherit",
+    stdout: "inherit",
+  }).spawn();
+
+  const status = await p.status;
+
+  if (!status.success) throw new Error(`error executing wasm-opt`);
+  return await outputTempFile.readBytes();
+}
+
+async function fetchWithRetries(url: URL | string, maxRetries = 5) {
+  let sleepMs = 250;
+  let iterationCount = 0;
+  while (true) {
+    iterationCount++;
+    try {
+      const res = await fetch(url);
+      if (res.ok || iterationCount > maxRetries) {
+        return res;
+      }
+    } catch (err) {
+      if (iterationCount > maxRetries) {
+        throw err;
+      }
+    }
+    console.warn(`Failed fetching. Retrying in ${sleepMs}ms...`);
+    await new Promise((resolve) => setTimeout(resolve, sleepMs));
+    sleepMs = Math.min(sleepMs * 2, 10_000);
+  }
+}
+
+async function getWasmOptBinaryPath() {
+  const cacheDirPathText = cacheDir();
+  if (!cacheDirPathText) {
+    throw new Error("Could not find cache directory.");
+  }
+  const cacheDirPath = new Path(cacheDirPathText);
+  const tempDirPath = cacheDirPath.join("wasmbuild", tag);
+  const wasmOptExePath = tempDirPath.join(
+    `binaryen-${tag}/bin`,
+    wasmOptFileName,
+  );
+
+  if (!(await wasmOptExePath.exists())) {
+    await downloadBinaryen(tempDirPath);
+    if (!(await wasmOptExePath.exists())) {
+      throw new Error(
+        `For some reason the wasm-opt executable did not exist after downloading at ${wasmOptExePath}.`,
+      );
+    }
+  }
+
+  return wasmOptExePath;
+}
+
+async function downloadBinaryen(tempPath: Path) {
+  console.error(`${colors.bold.green("Downloading")} wasm-opt binary...`);
+
+  const response = await fetchWithRetries(binaryenUrl());
+  const entries = response.body?.pipeThrough(
+    new DecompressionStream("gzip"),
+  )?.pipeThrough(new UntarStream());
+
+  for await (const entry of entries ?? []) {
+    if (
+      entry.path.endsWith(wasmOptFileName) ||
+      entry.path.endsWith(".dylib")
+    ) {
+      const filePath = tempPath.join(entry.path);
+      await filePath.parentOrThrow().ensureDir();
+      await using file = await filePath.open({
+        create: true,
+        write: true,
+        mode: 0o755,
+      });
+      await entry.readable?.pipeTo(file.writable);
+    } else {
+      await entry.readable?.cancel();
+    }
+  }
+}
+
+function binaryenUrl() {
+  function getOs() {
+    switch (Deno.build.os) {
+      case "linux":
+        return "linux";
+      case "darwin":
+        return "macos";
+      case "windows":
+        return "windows";
+      default:
+        throw new Error("Unsupported OS");
+    }
+  }
+
+  const os = getOs();
+  const arch = {
+    "x86_64": "x86_64",
+    "aarch64": "arm64",
+  }[Deno.build.arch];
+  return new URL(
+    `https://github.com/WebAssembly/binaryen/releases/download/${tag}/binaryen-${tag}-${arch}-${os}.tar.gz`,
+  );
+}
+
+// MIT License - Copyright (c) justjavac.
+// https://github.com/justjavac/deno_dirs/blob/e8c001bbef558f08fd486d444af391729b0b8068/cache_dir/mod.ts
+function cacheDir(): string | undefined {
+  switch (Deno.build.os) {
+    case "linux": {
+      const xdg = Deno.env.get("XDG_CACHE_HOME");
+      if (xdg) return xdg;
+      const home = Deno.env.get("HOME");
+      if (home) return `${home}/.cache`;
+      break;
+    }
+    case "darwin": {
+      const home = Deno.env.get("HOME");
+      if (home) return `${home}/Library/Caches`;
+      break;
+    }
+    case "windows":
+      return Deno.env.get("LOCALAPPDATA") ?? undefined;
+  }
+
+  return undefined;
+}
+
+if (import.meta.main) {
+  const [path, ...args] = Deno.args;
+  const file = new Path(path);
+  await runWasmOpt(await file.readBytes(), ...args);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate alloc;
 use alloc::boxed::Box;
+use alloc::string::ToString;
 use alloc::vec::Vec;
 use wasm_bindgen::prelude::*;
 
@@ -32,7 +33,7 @@ static ALLOCATOR: LockedAllocator<FreeListAllocator> =
 ///
 /// The output is a byte array containing the compressed data.
 pub fn compress(input: Box<[u8]>) -> Vec<u8> {
-  ::lz4_compression::prelude::compress(&mut input.as_ref())
+  ::lz4_flex::block::compress_prepend_size(&input.as_ref())
 }
 
 #[wasm_bindgen]
@@ -41,6 +42,12 @@ pub fn compress(input: Box<[u8]>) -> Vec<u8> {
 ///
 /// The input data is expected to be a byte array.
 /// The output is a byte array containing the decompressed data.
-pub fn decompress(input: Box<[u8]>) -> Vec<u8> {
-  ::lz4_compression::prelude::decompress(&mut input.as_ref()).unwrap()
+pub fn decompress(input: Box<[u8]>) -> Result<Vec<u8>, JsValue> {
+  ::lz4_flex::block::decompress_size_prepended(&input.as_ref())
+    .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+  loop {} // no-op panic handler for WebAssembly
 }


### PR DESCRIPTION
This PR introduces a number of optimizations that collectively result in a
very significant performance improvement.

The most notable change is the switch to the `lz4_flex` crate, which provides a
much faster implementation of the LZ4 compression algorithm.

After conducting a litany of benchmarks with various optimization levels, I
found the best results to from compiling with the rustc opt-level set to `s`,
and wasm-opt's `-O4`.

Together, these optimizations yield an LZ4 compression implementation that is
10-20x faster than the `https://deno.land/x/lz4` module, and 2-5x faster than
the previous version of this module.

Cheers!
- Nick

### Changelog

- **chore: update .gitignore**
- **perf(deps): switch to lz4_flex crate for 2-5x speed**
- **perf: switch to lz4_flex**
- **perf: add benchmarks**
- **config: update deno.json, add tasks**
- **fix: typos in readme**
- **config: add build and wasm-opt scripts**
